### PR TITLE
refactor: GCP 인증 방식 변경 (JSON 키 -> WIF 방식)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write  # WIF 토큰 발급에 필요
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,7 +29,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->

closes #6

## 📚 Summary
GCP 인증 방식을 서비스 계정 키(JSON) 기반에서 Workload Identity Federation(WIF)으로 전환했습니다.
장기 유효 자격증명을 GitHub Secrets에 저장하지 않고, GitHub OIDC 토큰을 통해 단기 자격증명을 발급받는 방식입니다.

## 🧩 As-is
- GCP_SA_KEY secret에 서비스 계정 키 JSON 전체를 저장
- 장기 유효 자격증명이 GitHub에 보관되어 키 유출 시 즉각적인 피해 가능
- 키 만료·로테이션을 수동으로 관리해야 함

## 🚀 To-be
- WIF_PROVIDER, WIF_SERVICE_ACCOUNT 두 값만 Secrets에 등록 (JSON 키 없음)
- GitHub Actions 실행 시 OIDC 토큰으로 단기 자격증명을 자동 발급·만료
- job에 id-token: write 권한 명시로 최소 권한 원칙 적용